### PR TITLE
support multiple arguments on actions

### DIFF
--- a/src/__tests__/__snapshots__/createStore-test.js.snap
+++ b/src/__tests__/__snapshots__/createStore-test.js.snap
@@ -105,3 +105,16 @@ exports[`Rendering the <Consumer> should support async actions 2`] = `
   </button>
 </div>
 `;
+
+exports[`Rendering the <Consumer> should support multiple arguments on actions 1`] = `
+<div>
+  <div>
+    7
+  </div>
+  <button
+    onClick={[Function]}
+  >
+    Increment
+  </button>
+</div>
+`;

--- a/src/__tests__/createStore-test.js
+++ b/src/__tests__/createStore-test.js
@@ -98,6 +98,35 @@ describe('Rendering the <Consumer>', () => {
     expect(tree.toJSON()).toMatchSnapshot()
   })
 
+  it('should support multiple arguments on actions', () => {
+    const { Provider, Consumer } = createStore({
+      model: 0,
+      actions: {
+        increment(state, stepper = 1, additionalStepper = 0) {
+          return state + stepper + additionalStepper
+        },
+      },
+    })
+
+    const tree = TestRenderer.create(
+      <Provider>
+        <Consumer>
+          {(state, actions) => (
+            <div>
+              <div>{JSON.stringify(state, null, 2)}</div>
+              <button onClick={() => actions.increment(5, 2)}>Increment</button>
+            </div>
+          )}
+        </Consumer>
+      </Provider>
+    )
+
+    tree.root.findByType('button').props.onClick()
+
+    expect(tree.getInstance().state.state).toBe(7)
+    expect(tree.toJSON()).toMatchSnapshot()
+  })
+
   it('should support async actions', async () => {
     const { Provider, Consumer } = createStore({
       model: 10,

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -32,8 +32,8 @@ export default function createStore(
 
         const initialState = props.initialState || options.model
         const resolvedActions = Object.keys(actions).reduce((map, name) => {
-          map[name] = payload => {
-            const newState = actions[name](this.state.state, payload)
+          map[name] = (...payload) => {
+            const newState = actions[name](this.state.state, ...payload)
             const isAsyncAction = newState.then !== undefined
 
             if (isAsyncAction) {


### PR DESCRIPTION
For now only one argument as `payload` is supported on the actions passed to the store.

I understand that this design is pushing towards composing a single object of all payload props, but it might be also good to support multiple arguments on actions too!

case:

```js
const actions = {
  increment(state, stepper = 1, additionalStepper = 0) {
    return state + stepper + additionalStepper
  }
}
```