### PR TITLE
Wrapper component

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -3,3 +3,4 @@
 1. [createStore](api/createStore.md)
 2. [Provider](api/Provider.md)
 3. [Consumer](api/Consumer.md)
+4. [Wrapper](api/Wrapper.md)

--- a/docs/api/Provider.md
+++ b/docs/api/Provider.md
@@ -17,15 +17,30 @@ const actions = {
   decrement: state => state - 1
 }
 
-const Counter = createStore({
+const CounterStore = createStore({
   actions,
   model
 })
 
-// This will render 10 rather than 0
+const Counter = () => (
+  <CounterStore.Provider>
+    <CounterStore.Consumer>
+      {state => state}
+    </CounterStore.Consumer>
+  </CounterStore.Provider>
+)
+```
+
+#### Using initialState
+
+The following example with start the counter from 10 instead of 0.
+
+```javascript
 const StartFrom10 = () => (
-  <Counter.Provider initialState={10}>
-    <Counter.Consumer>{state => state}</Counter.Consumer>
-  </Counter.Provider>
+  <CounterStore.Provider initialState={10}>
+    <CounterStore.Consumer>
+      {state => state}
+    </CounterStore.Consumer>
+  </CounterStore.Provider>
 )
 ```

--- a/docs/api/Wrapper.md
+++ b/docs/api/Wrapper.md
@@ -1,0 +1,34 @@
+# Wrapper
+
+Wrapper is just a convenient component that combines both [Provider](Provider.md) and [Consumer](Consumer.md) into a single component.<br>
+It helps to keep your component tree clean when using local state.
+
+It accepts all props that [Provider](Provider.md) and [Consumer](Consumer.md) accept and requires a render function passed as children.
+
+## Example
+```javascript
+import { createStore } from 'react-woodworm'
+
+const model = 0
+const actions = {
+  increment: state => state + 1,
+  decrement: state => state - 1
+}
+
+const Counter = createStore({
+  actions,
+  model
+})
+
+const renderCounter = ({ state, actions }) => (
+  <div>
+    <div>Counter: {state}
+    <button onClick={actions.increment}>+</button>
+    <button onClick={actions.decrement}>-</button>
+  </div>
+)
+
+const SimpleCounter = ({ defaultCount }) => (
+  <Counter.Wrapper>{renderCounter}</Counter.Wrapper>
+)
+```

--- a/docs/concepts/Actions.md
+++ b/docs/concepts/Actions.md
@@ -1,7 +1,13 @@
 # Actions
 
 Actions are used to update the state in a functional way.<br>
-They are so called **reducers** that receive both the current state and some payload and return the new state. While it doesn't enforce any restrictions on how to calculate the new state, here are some recommendations:
+They are so called **reducers** that receive both the current state and some payload and return the new state.
+
+```javascript
+const Action: any = (previousState: any, ...payload) => newState
+```
+
+While it doesn't enforce any restrictions on how to calculate the new state, here are some recommendations:
 
 * Do not mutate the current state, but rather use **immutable data structures**
 * Ensure that all actions are **pure functions**

--- a/docs/concepts/Effects.md
+++ b/docs/concepts/Effects.md
@@ -3,6 +3,10 @@
 Apart from [actions](Actions.md), there is another way to update the state: (side) effects.<br>
 Effects do not actually update the state directly, but rather call an equivalent action once resolved.
 
+```javascript
+const Effect: void = (actions: Object, ...payload) => {}
+```
+
 They're used for asynchronous operations such as API requests or delayed calls.<br>
 For example, sending an API request to get some user data will not immediately yield an answer. The server must first receive the call, process it and send an answer over the network which unfortunately takes some time.<br>
 

--- a/docs/concepts/Model.md
+++ b/docs/concepts/Model.md
@@ -2,3 +2,7 @@
 
 The model describes the initial state of a store.<br>
 It can be composed of any shape and can be filled with some default data before any [action](Actions.md) is called yet.
+
+```javascript
+const Model: any = any
+```

--- a/docs/examples/Counter.md
+++ b/docs/examples/Counter.md
@@ -1,0 +1,109 @@
+# Example: Counter
+
+The counter example has emerged as one of the most basic examples for showcasing state management tools. Here we go:
+
+### Basic Counter
+```javascript
+import React from 'react'
+import { createStore } from 'react-woodworm'
+
+const model = 0
+const actions {
+  increment: state => state + 1,
+  decrement: state => state - 1
+}
+
+const { Provider, Consumer } = createStore({
+  model,
+  actions
+})
+
+const Counter = () => (
+  <Provider>
+    <Consumer>
+      {({ state, actions }) => (
+        <div>
+          <div>{state}</div>
+          <button onClick={actions.increment}>+</button>
+          <button onClick={actions.decrement}>-</button>
+        </div>
+      )}
+    </Consumer>
+  </Provider>
+)
+```
+
+### Dynamic Steps
+Instead of always incrementing or decrementing by one, we can also pass a step value to e.g. increment by 5.
+
+```javascript
+import React from 'react'
+import { createStore } from 'react-woodworm'
+
+const model = 0
+const actions {
+  increment: state => state + 1,
+  decrement: state => state - 1,
+  incrementBy: (state, step) => state + step,
+  decrementBy: (state, step) => state - step
+}
+
+const { Provider, Consumer } = createStore({
+  model,
+  actions
+})
+
+const Counter = () => (
+  <Provider>
+    <Consumer>
+      {({ state, actions }) => (
+        <div>
+          <div>{state}</div>
+          <button onClick={actions.increment}>+</button>
+          <button onClick={actions.decrement}>-</button>
+          <button onClick={() => actions.incrementBy(5)}>+5</button>
+          <button onClick={() => actions.decrementBy(5)}>-5</button>
+        </div>
+      )}
+    </Consumer>
+  </Provider>
+)
+```
+
+### Asynchronous Steps
+Apart from triggering state changes through user interaction, we can also use effects to trigger changes asynchronously e.g. after a given delay.
+
+```javascript
+import React from 'react'
+import { createStore } from 'react-woodworm'
+
+const model = 0
+const actions {
+  increment: state => state + 1,
+  decrement: state => state - 1
+}
+const effects = {
+  incrementAfter: (actions, delay) => setTimeout(actions.increment, delay)
+}
+
+const { Provider, Consumer } = createStore({
+  model,
+  actions,
+  effects
+})
+
+const Counter = () => (
+  <Provider>
+    <Consumer>
+      {({ state, actions, effects }) => (
+        <div>
+          <div>{state}</div>
+          <button onClick={actions.increment}>+</button>
+          <button onClick={actions.decrement}>-</button>
+          <button onClick={() => effects.incrementAfter(1000)}>+ (delayed 1s)</button>
+        </div>
+      )}
+    </Consumer>
+  </Provider>
+)
+```

--- a/src/__tests__/createStore-test.js
+++ b/src/__tests__/createStore-test.js
@@ -8,7 +8,7 @@ describe('Creating a store', () => {
   it('should return a Consumer and a Provider', () => {
     const store = createStore()
 
-    expect(Object.keys(store)).toEqual(['Provider', 'Consumer'])
+    expect(Object.keys(store)).toEqual(['Provider', 'Consumer', 'Wrapper'])
   })
 })
 

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -22,53 +22,67 @@ export default function createStore(
   const actions = options.actions || {}
   const effects = options.effects || {}
 
+  class Provider extends Component {
+    state: {
+      state: any,
+      actions: Object,
+      effects: Object,
+    }
+
+    props: {
+      initialState: any,
+    }
+
+    constructor(props, context) {
+      super(props, context)
+
+      const initialState = props.initialState || options.model
+      const resolvedActions = Object.keys(actions).reduce((map, name) => {
+        map[name] = (...payload) =>
+          this.setState(prevState => ({
+            state: actions[name](prevState.state, ...payload),
+          }))
+
+        return map
+      }, {})
+
+      const setState = this.setState.bind(this)
+      const resolvedEffects = Object.keys(effects).reduce((map, name) => {
+        map[name] = (...payload) => effects[name](resolvedActions, ...payload)
+        return map
+      }, {})
+
+      this.state = {
+        state: initialState,
+        actions: resolvedActions,
+        effects: resolvedEffects,
+      }
+    }
+
+    render() {
+      return (
+        <Store.Provider value={this.state}>
+          {this.props.children}
+        </Store.Provider>
+      )
+    }
+  }
+
+  const Consumer = ({ children }) => (
+    <Store.Consumer>
+      {store => validateStore(store) && children(store)}
+    </Store.Consumer>
+  )
+
+  const Wrapper = ({ children, initialState }) => (
+    <Provider initialState={initialState}>
+      <Consumer>{children}</Consumer>
+    </Provider>
+  )
+
   return {
-    Provider: class Provider extends Component {
-      state: {
-        state: any,
-        actions: Object,
-        effects: Object,
-      }
-
-      constructor(props, context) {
-        super(props, context)
-
-        const initialState = props.initialState || options.model
-        const resolvedActions = Object.keys(actions).reduce((map, name) => {
-          map[name] = (...payload) =>
-            this.setState(prevState => ({
-              state: actions[name](prevState.state, ...payload),
-            }))
-
-          return map
-        }, {})
-
-        const setState = this.setState.bind(this)
-        const resolvedEffects = Object.keys(effects).reduce((map, name) => {
-          map[name] = (...payload) => effects[name](resolvedActions, ...payload)
-          return map
-        }, {})
-
-        this.state = {
-          state: initialState,
-          actions: resolvedActions,
-          effects: resolvedEffects,
-        }
-      }
-
-      render() {
-        return (
-          <Store.Provider value={this.state}>
-            {this.props.children}
-          </Store.Provider>
-        )
-      }
-    },
-
-    Consumer: ({ children }) => (
-      <Store.Consumer>
-        {store => validateStore(store) && children(store)}
-      </Store.Consumer>
-    ),
+    Provider,
+    Consumer,
+    Wrapper,
   }
 }


### PR DESCRIPTION
This PR adds a Wrapper component that is a convenient shorthand for the Provider, Consumer pair when working with local state.

```javascript
const Counter = createStore({
  model: 0,
  actions: {
    increment: state => state + 1,
    decrement: state => state - 1,
  }
})

const Tree = () => (
  < Counter.Wrapper initialState={5}>
    {({ state, actions }) => (
      <div>
        <div>{state}</div>
        <button onClick={actions.increment}>+</button>
        <button onClick={actions.decrement}>-</button>
      </div>
    )}
  </Counter.Wrapper>
)