### PR TITLE
Add Typescript support

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
     "LICENSE",
     "README.md",
     "lib/**",
-    "es/**"
+    "es/**",
+    "types/index.d.ts"
   ],
+  "types": "types/index.d.ts",
   "repository": "https://github.com/rofrischmann/alveron/",
   "keywords": [
     "react",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,39 @@
+type Action = (state: any, ...payload: Array<any>) => any
+type ActionMap = {
+  [actionName: string]: Action,
+}
+type ResolvedAction = (...payload: Array<any>) => void
+type ResolvedActionMap = {
+  [actionName: string]: ResolvedAction,
+}
+
+type Effect = (
+  actions: ResolvedActionMap,
+  effects: ResolvedEffectMap,
+  ...payload: Array<any>
+) => void
+type EffectMap = {
+  [effectName: string]: Effect,
+}
+type ResolvedEffect = (...payload: Array<any>) => void
+type ResolvedEffectMap = {
+  [effectName: string]: ResolvedEffect,
+}
+
+export interface OptionsShape {
+  model?: any,
+  actions?: ActionMap,
+  effects?: EffectMap,
+}
+
+export interface InterfaceShape {
+  state: any,
+  actions: ResolvedActionMap,
+  effects: ResolvedEffectMap,
+}
+
+export interface RenderPropsShape {
+  Consumer: any,
+  Provider: any,
+  Wrapper: any,
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -37,3 +37,6 @@ export interface RenderPropsShape {
   Provider: any,
   Wrapper: any,
 }
+
+declare const createStore: (options: OptionsShape) => RenderPropsShape
+declare const useAlveron: (options: OptionsShape) => InterfaceShape


### PR DESCRIPTION
This is related to #13 

Currently I have successfully tested alveron within a React Native project in Typescript directly from my fork.